### PR TITLE
Only log requests to STDOUT when debug flag is given

### DIFF
--- a/lib/supportbee.rb
+++ b/lib/supportbee.rb
@@ -3,6 +3,3 @@ require 'json/ext'
 require 'openssl'
 require 'faraday'
 require 'json'
-
-OpenSSL::SSL.send :remove_const, :VERIFY_PEER
-OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE

--- a/lib/supportbee/client.rb
+++ b/lib/supportbee/client.rb
@@ -17,7 +17,9 @@ module Supportbee
       @conn = Faraday.new(:url => @host) do |faraday|
         faraday.params[:auth_token] = @auth_token
         faraday.request  :url_encoded             # form-encode POST params
-        faraday.response :logger                  # log requests to STDOUT
+        if options[:debug]
+          faraday.response :logger                  # log requests to STDOUT
+        end
         faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
       end
     end


### PR DESCRIPTION
The fact that the gem always logs to stdout is distracting, especially in unit tests. This change makes logging optional.
